### PR TITLE
Passer les contracts en derniere version 0.8.11

### DIFF
--- a/contracts/LeafDapp.sol
+++ b/contracts/LeafDapp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./LeafToken.sol";

--- a/contracts/LeafNft.sol
+++ b/contracts/LeafNft.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/LeafToken.sol
+++ b/contracts/LeafToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,12 @@
+To generate solidity contract documentation, follow instruction bellow.
+
+To switch the solidity-docgen version to use solc with version 0.8 instead 0.6 run :
+npm install -D solc-0.8@npm:solc@^0.8.0
+npx solidity-docgen --solc-module solc-0.8
+
+Generate documentation
+solidity-docgen
+
+[Leaf Token contract documentation](../docs/leafToken.md)
+[Leaf NFT contract documentation](../docs/leafNft.md)
+[Leaf dApp contract documentation](../docs/leafDapp.md)

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.8.10",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.11",    // Fetch exact version from solc-bin (default: truffle's version)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {
          enabled: false,


### PR DESCRIPTION
Car solidity-docgen utilise solc qui lui utilise la derniere version pour s'executer